### PR TITLE
fix: update minSdk where required

### DIFF
--- a/plugins/dartnative_background/example/android/app/build.gradle.kts
+++ b/plugins/dartnative_background/example/android/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.dartnative.backgroundExample"
-        minSdk = 24
+        minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/plugins/dartnative_hive/example/android/app/build.gradle.kts
+++ b/plugins/dartnative_hive/example/android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         applicationId = "com.dartnative.hiveExample"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/plugins/dartnative_notifications/example/lib/main.dart
+++ b/plugins/dartnative_notifications/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:dartnative/dartnative.dart';
-
+import 'package:dartnative_notifications/dartnative_notifications.dart';
 import 'dartnative_plugin_registrant.dart';
 import 'screens/notifications_demo.dart';
 


### PR DESCRIPTION
Updates minSdk to 26 only for the examples/packages that require it.
